### PR TITLE
fix: revert desktop spec rename

### DIFF
--- a/src/app/core.ts
+++ b/src/app/core.ts
@@ -3,7 +3,7 @@ import {client} from '../helpers/client/client';
 import {errorLog, generateErrorBody, generatePromiseObjects, isValidTransferSpec, randomUUID, throwError} from '../helpers/helpers';
 import {asperaBrowser} from '../index';
 import {BrowserInfo, TransferResponse} from '../models/aspera-browser.model';
-import {CustomBrandingOptions, DataTransferResponse, BrowserSpec, BrowserStyleFile, BrowserTransfer, FileDialogOptions, FolderDialogOptions, InitOptions, ModifyTransferOptions, ResumeTransferOptions, SafariExtensionEvent, TransferSpec, WebsocketEvent} from '../models/models';
+import {CustomBrandingOptions, DataTransferResponse, BrowserStyleFile, BrowserTransfer, DesktopSpec, FileDialogOptions, FolderDialogOptions, InitOptions, ModifyTransferOptions, ResumeTransferOptions, SafariExtensionEvent, TransferSpec, WebsocketEvent} from '../models/models';
 
 /**
  * Check if IBM Aspera for Desktop connection works. This function is called by init
@@ -88,11 +88,11 @@ export const init = (options?: InitOptions): Promise<any> => {
  * Start a transfer
  *
  * @param transferSpec standard transferSpec for transfer
- * @param browserSpec IBM Aspera Browser settings when starting a transfer
+ * @param desktopSpec IBM Aspera for Desktop settings when starting a transfer
  *
  * @returns a promise that resolves if transfer initiation is successful and rejects if transfer cannot be started
  */
-export const startTransfer = (transferSpec: TransferSpec, browserSpec: BrowserSpec): Promise<BrowserTransfer> => {
+export const startTransfer = (transferSpec: TransferSpec, desktopSpec: DesktopSpec): Promise<BrowserTransfer> => {
   if (!asperaBrowser.isReady) {
     return throwError(messages.serverNotVerified);
   }
@@ -105,7 +105,7 @@ export const startTransfer = (transferSpec: TransferSpec, browserSpec: BrowserSp
 
   const payload = {
     transfer_spec: transferSpec,
-    browser_spec: browserSpec,
+    desktop_spec: desktopSpec,
     app_id: asperaBrowser.globals.appId,
   };
 

--- a/src/index.html
+++ b/src/index.html
@@ -165,7 +165,7 @@
       }
 
       function testServer() {
-        asperaBrowser.testBrowserConnection().then(response => {
+        asperaBrowser.testConnection().then(response => {
           console.log('TEST SUCCESS', response);
         }).catch(error => {
           console.log('TEST FAIL', error);
@@ -181,13 +181,13 @@
       }
 
       function transfer() {
-        const browserSpec = {
+        const desktopSpec = {
           use_absolute_destination_path: false
         };
 
         try {
           const transferSpec = JSON.parse(document.querySelector('#test-input').value);
-          asperaBrowser.startTransfer(transferSpec, browserSpec).then(response => {
+          asperaBrowser.startTransfer(transferSpec, desktopSpec).then(response => {
             console.log('TRANSFER SUCCESS', response);
           }).catch(error => {
             console.log('TRANSFER FAIL', error);

--- a/src/models/aspera-browser.model.ts
+++ b/src/models/aspera-browser.model.ts
@@ -1,4 +1,4 @@
-import {CustomBrandingOptions, DataTransferResponse, BrowserSpec, BrowserTransfer, FileDialogOptions, FolderDialogOptions, InitOptions, InstallerInfoResponse, InstallerOptions, ModifyTransferOptions, ResumeTransferOptions, SafariExtensionEvent, TransferSpec, WebsocketEvent} from './models';
+import {CustomBrandingOptions, DataTransferResponse, BrowserTransfer, DesktopSpec, FileDialogOptions, FolderDialogOptions, InitOptions, InstallerInfoResponse, InstallerOptions, ModifyTransferOptions, ResumeTransferOptions, SafariExtensionEvent, TransferSpec, WebsocketEvent} from './models';
 import {hiddenStyleList, installerUrl, protocol} from '../constants/constants';
 import {messages} from '../constants/messages';
 import {safariClient} from '../helpers/client/safari-client';
@@ -295,7 +295,7 @@ export class Browser {
   /** Function to test the IBM Aspera Browser status */
   testConnection: () => Promise<any>;
   /** Function to initiate a transfer */
-  startTransfer: (transferSpec: TransferSpec, browserSpec: BrowserSpec) => Promise<BrowserTransfer>;
+  startTransfer: (transferSpec: TransferSpec, desktopSpec: DesktopSpec) => Promise<BrowserTransfer>;
   /** Function to launch IBM Aspera Browser */
   launch: () => void;
   /** Register callback for the transfer activity monitor */

--- a/src/models/models.ts
+++ b/src/models/models.ts
@@ -132,7 +132,7 @@ export interface CustomBrandingOptions {
   theme: CustomTheme;
 }
 
-export interface BrowserSpec {
+export interface DesktopSpec {
   /**
    * By default, the destination of a download is relative to the user's download directory setting.
    * Setting this value to `true` overrides this behavior, using absolute paths instead. This is useful


### PR DESCRIPTION
Revert `DesktopSpec` mistakenly renamed to `BrowserSpec`